### PR TITLE
Update website when a new preview is released

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.WEBSITE_REPO_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/mihon/website/dispatches \
-          -d '{"event_type":"new_app_version"}'
+          -d '{"event_type":"app_release"}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,3 +153,13 @@ jobs:
         with:
           keep_latest: 28
           delete_tags: true
+
+      - name: Update website
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.WEBSITE_REPO_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/mihon/website/dispatches \
+          -d '{"event_type":"new_app_version"}'


### PR DESCRIPTION
Goes with: https://github.com/mihonapp/website/pull/141

This will send a "new_app_version" event to the website repo to update it with the freshly published preview.

Tested with a simplified workflow that doesn't have any other steps: https://github.com/scb261/mihon-preview/actions/runs/13632085650
And the event was successfully received: https://github.com/scb261/website/actions/runs/13632089007

This also requires a secret to be configured:

1. Create a token that has access to the website repo. I have tested it with a fine-grained personal access token that has write access to the repo as specified in the docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

![image](https://github.com/user-attachments/assets/ee833c10-be36-434d-93dd-c219fa7a040b)

2. Put the token in the secrets of this repo as WEBSITE_REPO_TOKEN (let me know if you want a different name).

If everything is okay, can add the same to the main app repo.