### PR TITLE
Rework website update workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,13 +153,3 @@ jobs:
         with:
           keep_latest: 28
           delete_tags: true
-
-      - name: Update website
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/mihonapp/website/dispatches \
-          -d '{"event_type":"app_release"}'

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -2,7 +2,10 @@ name: Post release
 
 on:
   release:
-    types: [published]
+    types: 
+      - published
+      - unpublished
+      - edited
 
 jobs:
   post_release:

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -8,7 +8,7 @@ on:
       - edited
 
 jobs:
-  post_release:
+  update_website:
     runs-on: 'ubuntu-24.04'
 
     steps:

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Update website
         run: |
-          curl --fail -L \
+          curl --fail-with-body -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,20 @@
+name: Post release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  post_release:
+    runs-on: 'ubuntu-24.04'
+
+    steps:
+      - name: Update website
+        run: |
+          curl --fail -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/mihonapp/website/dispatches \
+          -d '{"event_type":"app_release"}'


### PR DESCRIPTION
Follow up for #34

Needed for the main repo, but also doing it here on preview.

Why: the previous implementation didn't work properly because the build CI in the main repo does only a draft release. This PR separates the website update into a separate workflow that is triggered on an actual release.

Also added `--fail-with-body` to curl so that the action fails when the event couldn't be sent successfully. 