### PR TITLE
Fix website update when a release is removed

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: 
       - published
-      - unpublished
+      - deleted
       - edited
 
 jobs:


### PR DESCRIPTION
I still don't know when the "unpublished" event is triggered, but after more testing, it seems to work with "deleted"