### PR TITLE
ci: replace the get-latest-release action with github cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,22 +56,12 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
           BUILD_TOOLS_VERSION: '35.0.1'
-      
-      - name: Clone Preview Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: 'mihonapp/mihon-preview'
-          fetch-depth: 0
-          path: 'preview'
           
       - name: Get previous release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the latest release tag from the preview repository
-          cd preview
-
-          OUTPUT=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
+          OUTPUT=$(gh release list --repo mihonapp/mihon-preview --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
           if [ -n "$OUTPUT" ]; then
             echo "TAG_NAME=$OUTPUT" >> $GITHUB_ENV
             echo "Latest Tag: $OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: '35.0.1' 
+          BUILD_TOOLS_VERSION: '35.0.1'
 
       - name: Prepare changelog
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
   build:
     name: Build app
     runs-on: 'ubuntu-24.04'
-
+    env:
+      TAG_NAME: ''
     steps:
       - name: Clone Repository (Latest)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -57,14 +58,28 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
           BUILD_TOOLS_VERSION: '35.0.1'
-
-      - name: Get previous release
-        id: last_release
-        uses: InsonusK/get-latest-release@7a9ff16c8c6b7ead5d71c0f1cc61f2703170eade # v1.1.0
+      
+      - name: Clone Preview Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          myToken: ${{ github.token }}
-          exclude_types: 'draft|prerelease'
-          view_top: 1
+          repository: 'mihonapp/mihon-preview'
+          fetch-depth: 0
+          path: 'preview'
+          
+      - name: Get previous release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the latest release tag from the preview repository
+          cd preview
+
+          if OUTPUT=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq '.[0].tagName'); then
+            echo "TAG_NAME=$OUTPUT" >> $GITHUB_ENV
+            echo "Latest Tag: $OUTPUT"
+          else
+            echo "Failed to get repository information"
+            exit 1
+          fi
 
       - name: Prepare changelog
         run: |
@@ -75,7 +90,7 @@ jobs:
           current_sha=$(git rev-parse --short HEAD)
           echo "CURRENT_SHA=$current_sha" >> $GITHUB_ENV
 
-          prev_commit_count=$(echo "${{ steps.last_release.outputs.tag_name }}" | sed -e "s/^r//")
+          prev_commit_count=$(echo "${{ env.TAG_NAME }}" | sed -e "s/^r//")
           commit_count_diff=$(expr $commit_count - $prev_commit_count)
           prev_release_sha=$(git rev-parse --short HEAD~$commit_count_diff)
           echo "PREV_RELEASE_SHA=$prev_release_sha" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
   build:
     name: Build app
     runs-on: 'ubuntu-24.04'
-    env:
-      TAG_NAME: ''
     steps:
       - name: Clone Repository (Latest)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,15 +66,15 @@ jobs:
           current_sha=$(git rev-parse --short HEAD)
           echo "CURRENT_SHA=$current_sha" >> $GITHUB_ENV
 
-          OUTPUT=$(gh release list --repo mihonapp/mihon-preview --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
-          if [ -n "$OUTPUT" ]; then
-            echo "Latest Tag: $OUTPUT"
+          tag_name=$(gh release list --repo mihonapp/mihon-preview --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
+          if [ -n "$tag_name" ]; then
+            echo "Latest Tag: $tag_name"
           else
             echo "Failed to get repository information"
             exit 1
           fi
 
-          prev_commit_count=$(echo "$OUTPUT" | sed -e "s/^r//")
+          prev_commit_count=$(echo "$tag_name" | sed -e "s/^r//")
           commit_count_diff=$(expr $commit_count - $prev_commit_count)
           prev_release_sha=$(git rev-parse --short HEAD~$commit_count_diff)
           echo "PREV_RELEASE_SHA=$prev_release_sha" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,20 +55,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: '35.0.1'
-          
-      - name: Get previous release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          OUTPUT=$(gh release list --repo mihonapp/mihon-preview --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
-          if [ -n "$OUTPUT" ]; then
-            echo "TAG_NAME=$OUTPUT" >> $GITHUB_ENV
-            echo "Latest Tag: $OUTPUT"
-          else
-            echo "Failed to get repository information"
-            exit 1
-          fi
+          BUILD_TOOLS_VERSION: '35.0.1' 
 
       - name: Prepare changelog
         run: |
@@ -79,7 +66,15 @@ jobs:
           current_sha=$(git rev-parse --short HEAD)
           echo "CURRENT_SHA=$current_sha" >> $GITHUB_ENV
 
-          prev_commit_count=$(echo "${{ env.TAG_NAME }}" | sed -e "s/^r//")
+          OUTPUT=$(gh release list --repo mihonapp/mihon-preview --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
+          if [ -n "$OUTPUT" ]; then
+            echo "Latest Tag: $OUTPUT"
+          else
+            echo "Failed to get repository information"
+            exit 1
+          fi
+
+          prev_commit_count=$(echo "$OUTPUT" | sed -e "s/^r//")
           commit_count_diff=$(expr $commit_count - $prev_commit_count)
           prev_release_sha=$(git rev-parse --short HEAD~$commit_count_diff)
           echo "PREV_RELEASE_SHA=$prev_release_sha" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,8 @@ jobs:
           # Get the latest release tag from the preview repository
           cd preview
 
-          if OUTPUT=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq '.[0].tagName'); then
+          OUTPUT=$(gh release list --exclude-drafts --exclude-pre-releases --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName')
+          if [ -n "$OUTPUT" ]; then
             echo "TAG_NAME=$OUTPUT" >> $GITHUB_ENV
             echo "Latest Tag: $OUTPUT"
           else


### PR DESCRIPTION
Resolved deprecation error with CI Build by replacing the `get-latest-release` action with the equivalent github cli

<img width="1270" height="429" alt="image" src="https://github.com/user-attachments/assets/9c8d6005-695b-4545-b517-572452a5277b" />

---

Documentation

https://cli.github.com/manual/gh_release_list

---

The test repo I was doing with

Yaml:

https://github.com/ArthurKun21/test-auto-pr-create/blob/main/.github/workflows/output.yml

Build:

https://github.com/ArthurKun21/test-auto-pr-create/actions/runs/16610560762/job/46992651765