### PR TITLE
re add the github token to Prepare changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
           BUILD_TOOLS_VERSION: '35.0.1'
 
       - name: Prepare changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 


### PR DESCRIPTION
When I moved the `Get previous release` step to `Prepare changelog` step I forgot to re-add the token. My bad

https://github.com/mihonapp/mihon-preview/pull/41/commits/b09e134c2313774a0629a596f9ad2591c622ea7c